### PR TITLE
Update travis-ci to use dmd-2.077.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ language: d
 
 install:
   # dmd
-  - DMD_VERSION=2.064.2
-  - RELEASE_YEAR=2013
-  - wget http://downloads.dlang.org/releases/${RELEASE_YEAR}/dmd.${DMD_VERSION}.zip
-  - unzip dmd.${DMD_VERSION}.zip
+  - DMD_VERSION=2.077.0
+  - RELEASE_YEAR=2017
+  - wget http://downloads.dlang.org/releases/${RELEASE_YEAR}/dmd.${DMD_VERSION}.linux.zip
+  - unzip dmd.${DMD_VERSION}.linux.zip
 
 script:
   - DMD=./dmd2/linux/bin64/dmd MODEL=64 make -f posix.mak unittest


### PR DESCRIPTION
Old DMD lacks `@nogc`
Needed by pull request https://github.com/repeatedly/xxhash-d/pull/4

EDIT: I mean `@nogc`, not `@safe`